### PR TITLE
Add monthChanged Event

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { WCDatepickerLabels } from "./components/wc-datepicker/wc-datepicker";
+import { MonthChangedEventDetails, WCDatepickerLabels } from "./components/wc-datepicker/wc-datepicker";
 export namespace Components {
     interface WcDatepicker {
         "clearButtonContent"?: string;
@@ -53,6 +53,7 @@ declare namespace LocalJSX {
         "locale"?: string;
         "nextMonthButtonContent"?: string;
         "nextYearButtonContent"?: string;
+        "onMonthChanged"?: (event: WcDatepickerCustomEvent<MonthChangedEventDetails>) => void;
         "onSelectDate"?: (event: WcDatepickerCustomEvent<string | string[] | undefined>) => void;
         "previousMonthButtonContent"?: string;
         "previousYearButtonContent"?: string;

--- a/src/components/wc-datepicker/wc-datepicker.spec.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.spec.tsx
@@ -303,6 +303,9 @@ describe('wc-datepicker', () => {
       language: 'en'
     });
 
+    const spy = jest.fn();
+    page.root.addEventListener('monthChanged', spy);
+
     const monthSelect = page.root.querySelector<HTMLSelectElement>(
       '.wc-datepicker__month-select'
     );
@@ -327,16 +330,19 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(header.innerText.startsWith('May')).toBeTruthy();
+    expect(spy.mock.calls[0][0].detail).toEqual({ month: 4, year: 2022 });
 
     previousMonthButton.click();
     await page.waitForChanges();
 
     expect(header.innerText.startsWith('April')).toBeTruthy();
+    expect(spy.mock.calls[1][0].detail).toEqual({ month: 3, year: 2022 });
 
     nextMonthButton.click();
     await page.waitForChanges();
 
     expect(header.innerText.startsWith('May')).toBeTruthy();
+    expect(spy.mock.calls[2][0].detail).toEqual({ month: 4, year: 2022 });
   });
 
   it('changes year', async () => {
@@ -345,6 +351,9 @@ describe('wc-datepicker', () => {
       html: `<wc-datepicker show-year-stepper="true" start-date="2022-01-01"></wc-datepicker>`,
       language: 'en'
     });
+
+    const spy = jest.fn();
+    page.root.addEventListener('monthChanged', spy);
 
     const yearSelect = page.root.querySelector<HTMLInputElement>(
       '.wc-datepicker__year-select'
@@ -370,16 +379,19 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(header.innerText.includes('1989')).toBeTruthy();
+    expect(spy.mock.calls[0][0].detail).toEqual({ month: 0, year: 1989 });
 
     previousYearButton.click();
     await page.waitForChanges();
 
     expect(header.innerText.includes('1988')).toBeTruthy();
+    expect(spy.mock.calls[1][0].detail).toEqual({ month: 0, year: 1988 });
 
     nextYearButton.click();
     await page.waitForChanges();
 
     expect(header.innerText.includes('1989')).toBeTruthy();
+    expect(spy.mock.calls[2][0].detail).toEqual({ month: 0, year: 1989 });
   });
 
   it('jumps to current month', async () => {

--- a/src/components/wc-datepicker/wc-datepicker.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.tsx
@@ -52,6 +52,11 @@ const defaultLabels: WCDatepickerLabels = {
   yearSelect: 'Select year'
 };
 
+export interface MonthChangedEventDetails {
+  month: number;
+  year: number;
+}
+
 @Component({
   scoped: true,
   shadow: false,
@@ -85,6 +90,7 @@ export class WCDatepicker {
   @State() weekdays: string[][];
 
   @Event() selectDate: EventEmitter<string | string[] | undefined>;
+  @Event() monthChanged: EventEmitter<MonthChangedEventDetails>;
 
   private moveFocusAfterMonthChanged: Boolean;
 
@@ -191,12 +197,19 @@ export class WCDatepicker {
   }
 
   private updateCurrentDate(date: Date, moveFocus?: boolean) {
-    const monthChanged =
-      date.getMonth() !== this.currentDate.getMonth() ||
-      date.getFullYear() !== this.currentDate.getFullYear();
+    const month = date.getMonth();
+    const year = date.getFullYear();
 
-    if (monthChanged && moveFocus) {
-      this.moveFocusAfterMonthChanged = true;
+    const monthChanged =
+      month !== this.currentDate.getMonth() ||
+      year !== this.currentDate.getFullYear();
+    
+    if (monthChanged) {
+      this.monthChanged.emit({ month, year });
+
+      if (moveFocus) {
+        this.moveFocusAfterMonthChanged = true;
+      }
     }
 
     this.currentDate = date;


### PR DESCRIPTION
Hi there 👋 

For my personal project I am in desperate need of an indication for month and year changes.

- Fire a `monthChanged` event whenever month or year has changed.
- Emit `{ month, year }` as event details