### PR TITLE
feat: prevent focus on disabled dates

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,6 +15,7 @@ export namespace Components {
         "firstDayOfWeek"?: number;
         "labels"?: WCDatepickerLabels;
         "locale"?: string;
+        "maxSearchDays"?: number;
         "nextMonthButtonContent"?: string;
         "nextYearButtonContent"?: string;
         "previousMonthButtonContent"?: string;
@@ -53,6 +54,7 @@ declare namespace LocalJSX {
         "firstDayOfWeek"?: number;
         "labels"?: WCDatepickerLabels;
         "locale"?: string;
+        "maxSearchDays"?: number;
         "nextMonthButtonContent"?: string;
         "nextYearButtonContent"?: string;
         "onChangeMonth"?: (event: WcDatepickerCustomEvent<MonthChangedEventDetails>) => void;

--- a/src/components/wc-datepicker/wc-datepicker.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.tsx
@@ -780,7 +780,7 @@ export class WCDatepicker {
                             role="gridcell"
                             tabIndex={
                               isSameDay(day, this.currentDate) &&
-                              !this.disableDate(day) &&
+                              !isDisabled &&
                               !this.disabled
                                 ? 0
                                 : -1


### PR DESCRIPTION
Hi,

This is a proposal to prevent focus on disabled dates (cf #25 ).
 I struggled to find a satisfying behavior, and eventually settled on the following one :
- up/down/left/right arrows will look for the first available (not disabled) date in the corresponding direction, up to a maximum difference in days (customizable via the `max-search-days` attribute)
- Home/End will look for the first/last available date in the current month
- Page up/down will look for the first available date in the previous/next month
- Shift + Page up/down will look for the next available date a year before/after the current date

Please let me know what you think.