### PR TITLE
Add 'aria-current' for today's date

### DIFF
--- a/src/components/wc-datepicker/wc-datepicker.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.tsx
@@ -795,6 +795,7 @@ export class WCDatepicker {
                           <td
                             aria-disabled={String(isDisabled)}
                             aria-selected={isSelected ? 'true' : undefined}
+                            aria-current={isToday ? 'date' : undefined}
                             class={className}
                             data-date={getISODateString(day)}
                             key={cellKey}


### PR DESCRIPTION
Adds `aria-current="date"` to indicate today's date to screen readers. 

Closes https://github.com/Sqrrl/wc-datepicker/issues/32.