### PR TITLE
feat: add goToRangeStartOnSelect prop for calendar view control after range selection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -467,6 +467,17 @@ defineCustomElements();</code></pre>
                 range selection is enabled.
               </td>
             </tr>
+            <tr>
+              <td><code>go-to-range-start-on-select</code></td>
+              <td><code>boolean</code></td>
+              <td><code>true</code></td>
+              <td>
+                Controls whether the calendar view switches to the start of the
+                range after the end date is selected. This only affects
+                selections where the start and end dates are in different
+                months.
+              </td>
+            </tr>
           </tbody>
         </table>
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ export namespace Components {
         "disabled"?: boolean;
         "elementClassName"?: string;
         "firstDayOfWeek"?: number;
+        "goToRangeStartOnSelect"?: boolean;
         "labels"?: WCDatepickerLabels;
         "locale"?: string;
         "maxSearchDays"?: number;
@@ -52,6 +53,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "elementClassName"?: string;
         "firstDayOfWeek"?: number;
+        "goToRangeStartOnSelect"?: boolean;
         "labels"?: WCDatepickerLabels;
         "locale"?: string;
         "maxSearchDays"?: number;

--- a/src/components/wc-datepicker/wc-datepicker.spec.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.spec.tsx
@@ -485,4 +485,29 @@ describe('wc-datepicker', () => {
 
     expect(yearSelect.value).toBe('0');
   });
+
+  it('respects goToRangeStartOnSelect by jumping to start or end of range', async () => {
+    const page = await newSpecPage({
+      components: [WCDatepicker],
+      html: `<wc-datepicker range></wc-datepicker>`,
+      language: 'en'
+    });
+
+    const jan1 = new Date('2022-01-01');
+    const mar1 = new Date('2022-03-01');
+
+    page.root.goToRangeStartOnSelect = true;
+    page.root.value = [jan1, mar1];
+    await page.waitForChanges();
+
+    expect(getSelectedMonth(page)).toBe(1);
+    expect(getSelectedYear(page)).toBe(2022);
+
+    page.root.goToRangeStartOnSelect = false;
+    page.root.value = [jan1, mar1];
+    await page.waitForChanges();
+
+    expect(getSelectedMonth(page)).toBe(3);
+    expect(getSelectedYear(page)).toBe(2022);
+  });
 });

--- a/src/components/wc-datepicker/wc-datepicker.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.tsx
@@ -89,6 +89,7 @@ export class WCDatepicker {
   @Prop() todayButtonContent?: string;
   @Prop({ mutable: true }) value?: Date | Date[];
   @Prop() maxSearchDays?: number = 365;
+  @Prop() goToRangeStartOnSelect?: boolean = true;
 
   @State() currentDate: Date;
   @State() hoveredDate: Date;
@@ -132,12 +133,16 @@ export class WCDatepicker {
 
   @Watch('value')
   watchValue() {
-    if (Boolean(this.value)) {
-      if (Array.isArray(this.value) && this.value.length >= 1) {
-        this.currentDate = this.value[0];
-      } else if (this.value instanceof Date) {
-        this.currentDate = this.value;
-      }
+    if (!Boolean(this.value)) {
+      return;
+    }
+
+    if (Array.isArray(this.value)) {
+      this.currentDate = this.value.length > 1 && !this.goToRangeStartOnSelect
+        ? this.value[1]
+        : this.value[0];
+    } else if (this.value instanceof Date) {
+      this.currentDate = this.value;
     }
   }
 


### PR DESCRIPTION
**What**
Adds a `goToRangeStartOnSelect` boolean prop (default true) to control which month the calendar displays after selecting a date range.

**Current behavior**
After range selection, the calendar jumps to the start date's month if the end date is in a different month.

**New behavior**
If `goToRangeStartOnSelect` is false, the calendar will stay on the end date's month instead.

**Why**
This helps avoid unexpected calendar jumps when selecting ranges that span multiple months.