### PR TITLE
[Improvement] Update changeMonth event to emit the day as well as the month and year

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -518,7 +518,7 @@ defineCustomElements();</code></pre>
             <tr>
               <td>changeMonth</td>
               <td>
-                <code>CustomEvent&lt;{ month: number; year: number; }&gt;</code>
+                <code>CustomEvent&lt;{ month: number; year: number; day: number }&gt;</code>
               </td>
               <td>Fired when the displayed month or year changes.</td>
             </tr>

--- a/src/components/wc-datepicker/wc-datepicker.spec.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.spec.tsx
@@ -322,17 +322,17 @@ describe('wc-datepicker', () => {
 
     await page.waitForChanges();
 
-    expect(spy.mock.calls[0][0].detail).toEqual({ month: 5, year: 2022 });
+    expect(spy.mock.calls[0][0].detail).toEqual({ month: 5, year: 2022, day: 1 });
 
     previousMonthButton.click();
     await page.waitForChanges();
 
-    expect(spy.mock.calls[1][0].detail).toEqual({ month: 4, year: 2022 });
+    expect(spy.mock.calls[1][0].detail).toEqual({ month: 4, year: 2022, day: 1 });
 
     nextMonthButton.click();
     await page.waitForChanges();
 
-    expect(spy.mock.calls[2][0].detail).toEqual({ month: 5, year: 2022 });
+    expect(spy.mock.calls[2][0].detail).toEqual({ month: 5, year: 2022, day: 1 });
   });
 
   it('changes year', async () => {
@@ -364,19 +364,19 @@ describe('wc-datepicker', () => {
 
     await page.waitForChanges();
 
-    expect(spy.mock.calls[0][0].detail).toEqual({ month: 1, year: 1989 });
+    expect(spy.mock.calls[0][0].detail).toEqual({ month: 1, year: 1989, day: 1 });
 
     previousYearButton.click();
     await page.waitForChanges();
 
     expect(yearSelect.value).toEqual('1988');
-    expect(spy.mock.calls[1][0].detail).toEqual({ month: 1, year: 1988 });
+    expect(spy.mock.calls[1][0].detail).toEqual({ month: 1, year: 1988, day: 1 });
 
     nextYearButton.click();
     await page.waitForChanges();
 
     expect(yearSelect.value).toEqual('1989');
-    expect(spy.mock.calls[2][0].detail).toEqual({ month: 1, year: 1989 });
+    expect(spy.mock.calls[2][0].detail).toEqual({ month: 1, year: 1989, day: 1 });
   });
 
   it('jumps to current month', async () => {

--- a/src/components/wc-datepicker/wc-datepicker.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.tsx
@@ -58,6 +58,7 @@ const defaultLabels: WCDatepickerLabels = {
 export interface MonthChangedEventDetails {
   month: number;
   year: number;
+  day: number;
 }
 
 @Component({
@@ -244,7 +245,7 @@ export class WCDatepicker {
       year !== this.currentDate.getFullYear();
 
     if (monthChanged) {
-      this.changeMonth.emit({ month: getMonth(date), year: getYear(date) });
+      this.changeMonth.emit({ month: getMonth(date), year: getYear(date), day: date.getDate() });
 
       if (moveFocus) {
         this.moveFocusAfterMonthChanged = true;


### PR DESCRIPTION
Thanks for a great simple and more importantly accessible date-picker!

I'm currently working on a small project which needs a little bit more programmatical control of it (extra / custom controls). Most of this can be controlled via the `start-date` value. 
Unfortunately encountered a limitation when a user uses keyboard navigation via the calendar grid to change months / years. The `changeMonth` event fires, however the current day might have changed when the month changes.

A super simple enhancement which resolves this is to allow the `changeMonth` event to provide the month, the year and the day. Gives consumers a little bit more flexibility and information about what is going on.

An alternative idea was to read the `currentDate` value, however as it isn't publicly available it didn't feel like that option was suitable. Marking it as `protected` (allow for inheritance) or a public `getCurrentDate` method could also work.
Given the existing `changeMonth` event does the job and a simple `day` value addition seems like a reasonable change, thought that might best (keep it simple) :)