### PR TITLE
feat: adding date description texts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -478,6 +478,22 @@ defineCustomElements();</code></pre>
                 months.
               </td>
             </tr>
+            <tr>
+              <td><code>show-day-descriptions</code></td>
+              <td><code>boolean</code></td>
+              <td><code>false</code></td>
+              <td>
+                Controls whether the day descriptions are shown in the calendar.
+              </td>
+            </tr>
+            <tr>
+              <td><code>addDateDescription</code></td>
+              <td><code>(date: Date) => string</code></td>
+              <td><code>Desc.</code></td>
+              <td>
+                A string to be used as the date description text.
+              </td>
+            </tr>
           </tbody>
         </table>
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,11 +8,14 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { MonthChangedEventDetails, WCDatepickerLabels } from "./components/wc-datepicker/wc-datepicker";
 export namespace Components {
     interface WcDatepicker {
+        "addDateDescription"?: (date: Date) => string;
         "clearButtonContent"?: string;
         "disableDate"?: (date: Date) => boolean;
         "disabled"?: boolean;
         "elementClassName"?: string;
         "firstDayOfWeek"?: number;
+        "getAllDayDescriptions": () => Promise<Record<string, string>>;
+        "getDescriptionForDay": (date: Date) => Promise<string>;
         "goToRangeStartOnSelect"?: boolean;
         "labels"?: WCDatepickerLabels;
         "locale"?: string;
@@ -23,6 +26,7 @@ export namespace Components {
         "previousYearButtonContent"?: string;
         "range"?: boolean;
         "showClearButton"?: boolean;
+        "showDayDescriptions"?: boolean;
         "showMonthStepper"?: boolean;
         "showTodayButton"?: boolean;
         "showYearStepper"?: boolean;
@@ -48,6 +52,7 @@ declare global {
 }
 declare namespace LocalJSX {
     interface WcDatepicker {
+        "addDateDescription"?: (date: Date) => string;
         "clearButtonContent"?: string;
         "disableDate"?: (date: Date) => boolean;
         "disabled"?: boolean;
@@ -65,6 +70,7 @@ declare namespace LocalJSX {
         "previousYearButtonContent"?: string;
         "range"?: boolean;
         "showClearButton"?: boolean;
+        "showDayDescriptions"?: boolean;
         "showMonthStepper"?: boolean;
         "showTodayButton"?: boolean;
         "showYearStepper"?: boolean;

--- a/src/components/wc-datepicker/wc-datepicker.spec.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.spec.tsx
@@ -183,7 +183,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('2');
 
@@ -191,7 +191,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('3');
 
@@ -199,7 +199,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('10');
 
@@ -207,7 +207,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('9');
 
@@ -215,7 +215,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('2');
 
@@ -223,7 +223,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('31');
 
@@ -231,7 +231,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('1');
 
@@ -239,7 +239,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('1');
 
@@ -247,7 +247,7 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(
-      page.root.querySelector('.wc-datepicker__date--current').children[0]
+      page.root.querySelector('.wc-datepicker__date--current .wc-datepicker__date-content').children[0]
         .innerHTML
     ).toBe('1');
   });
@@ -566,5 +566,34 @@ describe('wc-datepicker', () => {
     await page.waitForChanges();
 
     expect(component['hoveredDate']).toBeUndefined();
+  });
+
+  it('add date descriptions to date cells', async () => {
+    const page = await newSpecPage({
+      components: [WCDatepicker],
+      html: `<wc-datepicker showDayDescriptions></wc-datepicker>`,
+      language: 'en'
+    });
+
+    // Since months are zero based
+    const november = 11 - 1;
+    const dayThird = 3;
+    const descriptionText = 'Desc.';
+    const currentDate = new Date('2025-11-03');
+    const component = page.rootInstance as WCDatepicker;
+    page.root.startDate = currentDate;
+    component.showDayDescriptions = true;
+
+    component.addDateDescription = (date: Date) => {
+      if (date.getMonth() === november && date.getDate() === dayThird) return descriptionText;
+      return ``;
+    };
+    
+    await page.waitForChanges();
+    
+    const getDayWithDescription = await component.getDescriptionForDay(currentDate);
+    
+    expect(component.showDayDescriptions).toBe(true);
+    expect(getDayWithDescription).toBe(descriptionText);
   });
 });

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,16 @@
 
     <script>
       const datepicker = document.getElementById('datepicker');
+      datepicker.showDayDescriptions = true;
+
+      datepicker.addDateDescription = (date) => {
+        const day = date.getDate();
+        const month = date.getMonth();
+
+        if (month === 3 && day === 11) return '845';
+        if (month === 5 && day === 27) return '900';
+        return '';
+      };
 
       datepicker.addEventListener('selectDate', (event) => {
         console.log(event);

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -230,3 +230,21 @@ wc-datepicker {
   line-height: 1;
   cursor: pointer;
 }
+
+.wc-datepicker--with-descriptions .wc-datepicker__date-content {
+  position: relative;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 42px;
+  white-space: nowrap;
+  width: 35px;
+}
+
+.wc-datepicker--with-descriptions .wc-datepicker__date-description {
+  font-size: 8px;
+  position: absolute;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  top: 30px;
+}

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -224,3 +224,21 @@ wc-datepicker {
   line-height: 1;
   cursor: pointer;
 }
+
+.wc-datepicker--with-descriptions .wc-datepicker__date-content {
+  position: relative;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 42px;
+  white-space: nowrap;
+  width: 35px;
+}
+
+.wc-datepicker--with-descriptions .wc-datepicker__date-description {
+  font-size: 8px;
+  position: absolute;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  top: 30px;
+}


### PR DESCRIPTION
I'm working in a project that needs some description texts for some dates and in this PR I'm sending this change since it could be a common feature in some projects that have texts to display , like discounts or another information, on each field date.

## Example
<img width="281" height="322" alt="image" src="https://github.com/user-attachments/assets/247c7f85-3dc5-48c4-9ef5-ff043a575c14" />
