### PR TITLE
feat: add slots for customizing buttons' content

### DIFF
--- a/.changeset/curly-pants-behave.md
+++ b/.changeset/curly-pants-behave.md
@@ -1,0 +1,9 @@
+---
+'wc-datepicker': minor
+---
+
+Add slots for buttons' content (customizability)
+> **Note**: Usage of props `todayButtonContent` and `clearButtonContent` has been deprecated. While they still work,
+> expect this to be removed in a future major version. These properties haven't been documented anyway, so their usage
+> should be limited to some specific cases. You should use the new named slots `button-clear` and `button-today` for
+> customizing those buttons.

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,7 @@
         <li><a href="#install">Install</a></li>
         <li><a href="#usage">Usage</a></li>
         <li><a href="#options">Options</a></li>
+        <li><a href="#slots">Slots</a></li>
         <li><a href="#events">Events</a></li>
         <li><a href="#styling">Styling</a></li>
         <li><a href="#browser-support">Browser support</a></li>
@@ -413,7 +414,7 @@ defineCustomElements();</code></pre>
               <td><code>false</code></td>
               <td>Enable/disable range selection.</td>
             </tr>
-            <tr>
+            <tr id="labels">
               <td><code>labels</code></td>
               <td><code>WCDatepickerLabels</code></td>
               <td>See below.</td>
@@ -494,6 +495,64 @@ defineCustomElements();</code></pre>
   todayButton: 'Show today',
   yearSelect: 'Select year'
 }</code></pre>
+      </section>
+
+      <section>
+        <h2 id="slots">Slots</h2>
+
+        <p>Slots can be used to customize the appearance of some parts, that
+          you typically want to theme; e.g. you can include custom icons or use
+          complex HTML.</p>
+
+        <p><strong>Note:</strong> If you just want to change the labels of some
+          of those buttons, have a look at the
+          <a href="#labels"><code>labels</code> option</a>.</p>
+
+        <strong>Example:</strong>
+
+        <pre><code class="language-html">&lt;wc-datepicker show-clear-button show-today-button show-month-stepper show-year-stepper&gt;
+  &lt;span slot="button-today" class="icon-today"&gt;&lt;/span&gt;
+  &lt;span slot="button-clear" class="icon-clear"&gt;&lt;/span&gt;
+  &lt;span slot="button-month-next" class="icon-arrow-left"&gt;&lt;/span&gt;
+  &lt;span slot="button-year-next" class="icon-arrow-left-double"&gt;&lt;/span&gt;
+  &lt;span slot="button-month-prev" class="icon-arrow-right"&gt;&lt;/span&gt;
+  &lt;span slot="button-year-prev" class="icon-arrow-right-double"&gt;&lt;/span&gt;
+&lt;/wc-datepicker&gt;</code></pre>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>button-today</code></td>
+              <td>Changes the content of the optional today button.</td>
+            </tr>
+            <tr>
+              <td><code>button-clear</code></td>
+              <td>Changes the content of the optional clear button.</td>
+            </tr>
+            <tr>
+              <td><code>button-year-next</code></td>
+              <td>Changes the content of the optional next year button.</td>
+            </tr>
+            <tr>
+              <td><code>button-year-prev</code></td>
+              <td>Changes the content of the optional previous year button.</td>
+            </tr>
+            <tr>
+              <td><code>button-month-next</code></td>
+              <td>Changes the content of the optional next month button.</td>
+            </tr>
+            <tr>
+              <td><code>button-month-prev</code></td>
+              <td>Changes the content of the optional previous month button.</td>
+            </tr>
+          </tbody>
+        </table>
       </section>
 
       <section>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,9 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { MonthChangedEventDetails, WCDatepickerLabels } from "./components/wc-datepicker/wc-datepicker";
 export namespace Components {
     interface WcDatepicker {
+        /**
+          * @deprecated - use named slot `button-clear` instead
+         */
         "clearButtonContent"?: string;
         "disableDate"?: (date: Date) => boolean;
         "disabled"?: boolean;
@@ -27,6 +30,9 @@ export namespace Components {
         "showTodayButton"?: boolean;
         "showYearStepper"?: boolean;
         "startDate"?: string;
+        /**
+          * @deprecated - use named slot `button-today` instead
+         */
         "todayButtonContent"?: string;
         "value"?: Date | Date[];
     }
@@ -48,6 +54,9 @@ declare global {
 }
 declare namespace LocalJSX {
     interface WcDatepicker {
+        /**
+          * @deprecated - use named slot `button-clear` instead
+         */
         "clearButtonContent"?: string;
         "disableDate"?: (date: Date) => boolean;
         "disabled"?: boolean;
@@ -69,6 +78,9 @@ declare namespace LocalJSX {
         "showTodayButton"?: boolean;
         "showYearStepper"?: boolean;
         "startDate"?: string;
+        /**
+          * @deprecated - use named slot `button-today` instead
+         */
         "todayButtonContent"?: string;
         "value"?: Date | Date[];
     }

--- a/src/components/wc-datepicker/wc-datepicker.spec.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.spec.tsx
@@ -671,4 +671,68 @@ describe('wc-datepicker', () => {
     expect(component['currentDate']).toBeDefined();
     expect(component['currentDate'].toISOString()).toContain('2022-01-15');
   });
+
+  describe('slots', () => {
+    const slotHtml = {
+      nextYear: `<span slot="button-year-next">next year</span>`,
+      prevYear: `<span slot="button-year-prev">prev year</span>`,
+      nextMonth: `<span slot="button-month-next">next month</span>`,
+      prevMonth: `<span slot="button-month-prev">prev month</span>`,
+      clear: `<span slot="button-clear">clear</span>`,
+      today: `<span slot="button-today">today</span>`
+    };
+
+    it('contains slot content if given', async () => {
+      const page = await newSpecPage({
+        components: [WCDatepicker],
+        html: `<wc-datepicker show-year-stepper show-month-stepper show-clear-button show-today-button>
+  ${slotHtml.nextYear}
+  ${slotHtml.prevYear}
+  ${slotHtml.nextMonth}
+  ${slotHtml.prevMonth}
+  ${slotHtml.clear}
+  ${slotHtml.today}
+</wc-datepicker>`,
+        language: 'en'
+      });
+
+      await page.waitForChanges();
+
+      expect(page.root.querySelector('.wc-datepicker__previous-year-button').innerHTML)
+        .toContain(slotHtml.prevYear);
+      expect(page.root.querySelector('.wc-datepicker__previous-month-button').innerHTML)
+        .toContain(slotHtml.prevMonth);
+      expect(page.root.querySelector('.wc-datepicker__next-year-button').innerHTML)
+        .toContain(slotHtml.nextYear);
+      expect(page.root.querySelector('.wc-datepicker__next-month-button').innerHTML)
+        .toContain(slotHtml.nextMonth);
+      expect(page.root.querySelector('.wc-datepicker__today-button').innerHTML)
+        .toContain(slotHtml.today);
+      expect(page.root.querySelector('.wc-datepicker__clear-button').innerHTML)
+        .toContain(slotHtml.clear);
+    });
+
+    it('not contains slot content if not given', async () => {
+      const page = await newSpecPage({
+        components: [WCDatepicker],
+        html: `<wc-datepicker show-year-stepper show-month-stepper show-clear-button show-today-button></wc-datepicker>`,
+        language: 'en'
+      });
+
+      await page.waitForChanges();
+
+      expect(page.root.querySelector('.wc-datepicker__previous-year-button').innerHTML)
+        .not.toContain(slotHtml.prevYear);
+      expect(page.root.querySelector('.wc-datepicker__previous-month-button').innerHTML)
+        .not.toContain(slotHtml.prevMonth);
+      expect(page.root.querySelector('.wc-datepicker__next-year-button').innerHTML)
+        .not.toContain(slotHtml.nextYear);
+      expect(page.root.querySelector('.wc-datepicker__next-month-button').innerHTML)
+        .not.toContain(slotHtml.nextMonth);
+      expect(page.root.querySelector('.wc-datepicker__today-button').innerHTML)
+        .not.toContain(slotHtml.today);
+      expect(page.root.querySelector('.wc-datepicker__clear-button').innerHTML)
+        .not.toContain(slotHtml.clear);
+    });
+  });
 });

--- a/src/components/wc-datepicker/wc-datepicker.tsx
+++ b/src/components/wc-datepicker/wc-datepicker.tsx
@@ -61,6 +61,14 @@ export interface MonthChangedEventDetails {
   day: number;
 }
 
+/**
+ * @slot button-month-prev - content of the previous month button
+ * @slot button-month-next - content of the next month button
+ * @slot button-year-prev - content of the previous year button
+ * @slot button-year-next - content of the next year button
+ * @slot button-today - content of the today button
+ * @slot button-clear - content of the clear button
+ */
 @Component({
   scoped: true,
   shadow: false,
@@ -70,6 +78,9 @@ export interface MonthChangedEventDetails {
 export class WCDatepicker {
   @Element() el: HTMLElement;
 
+  /**
+   * @deprecated - use named slot `button-clear` instead
+   */
   @Prop() clearButtonContent?: string;
   @Prop() disabled?: boolean = false;
   @Prop() disableDate?: (date: Date) => boolean = () => false;
@@ -87,6 +98,9 @@ export class WCDatepicker {
   @Prop() showTodayButton?: boolean = false;
   @Prop() showYearStepper?: boolean = false;
   @Prop() startDate?: string = getISODateString(new Date());
+  /**
+   * @deprecated - use named slot `button-today` instead
+   */
   @Prop() todayButtonContent?: string;
   @Prop({ mutable: true }) value?: Date | Date[];
   @Prop() maxSearchDays?: number = 365;
@@ -630,19 +644,22 @@ export class WCDatepicker {
                 onClick={this.previousYear}
                 type="button"
               >
-                <svg
-                  fill="none"
-                  height="24"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <polyline points="11 17 6 12 11 7"></polyline>
-                  <polyline points="18 17 13 12 18 7"></polyline>
-                </svg>
+                <slot name="button-year-prev">
+                  <svg
+                    fill="none"
+                    height="24"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <polyline points="11 17 6 12 11 7"></polyline>
+                    <polyline points="18 17 13 12 18 7"></polyline>
+                  </svg>
+                </slot>
+
               </button>
             )}
             {this.showMonthStepper && (
@@ -654,18 +671,20 @@ export class WCDatepicker {
                 onClick={this.previousMonth}
                 type="button"
               >
-                <svg
-                  fill="none"
-                  height="24"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
+                <slot name="button-month-prev">
+                  <svg
+                    fill="none"
+                    height="24"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <polyline points="15 18 9 12 15 6"></polyline>
+                  </svg>
+                </slot>
               </button>
             )}
             <span class={this.getClassName('current-month')}>
@@ -708,18 +727,21 @@ export class WCDatepicker {
                 onClick={this.nextMonth}
                 type="button"
               >
-                <svg
-                  fill="none"
-                  height="24"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <polyline points="9 18 15 12 9 6"></polyline>
-                </svg>
+                <slot name="button-month-next">
+                  <svg
+                    fill="none"
+                    height="24"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <polyline points="9 18 15 12 9 6"></polyline>
+                  </svg>
+                </slot>
+
               </button>
             )}
             {this.showYearStepper && (
@@ -731,19 +753,22 @@ export class WCDatepicker {
                 onClick={this.nextYear}
                 type="button"
               >
-                <svg
-                  fill="none"
-                  height="24"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <polyline points="13 17 18 12 13 7"></polyline>
-                  <polyline points="6 17 11 12 6 7"></polyline>
-                </svg>
+                <slot name="button-year-next">
+                  <svg
+                    fill="none"
+                    height="24"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <polyline points="13 17 18 12 13 7"></polyline>
+                    <polyline points="6 17 11 12 6 7"></polyline>
+                  </svg>
+
+                </slot>
               </button>
             )}
           </div>
@@ -891,7 +916,7 @@ export class WCDatepicker {
                   onClick={this.showToday}
                   type="button"
                 >
-                  {this.labels.todayButton}
+                  <slot name="button-today">{this.labels.todayButton}</slot>
                 </button>
               )}
               {this.showClearButton && (
@@ -902,7 +927,7 @@ export class WCDatepicker {
                   onClick={this.clear}
                   type="button"
                 >
-                  {this.labels.clearButton}
+                  <slot name="button-clear">{this.labels.clearButton}</slot>
                 </button>
               )}
             </div>


### PR DESCRIPTION
see https://github.com/Sqrrl/wc-datepicker/issues/58

This deprecates the use of props `todayButtonContent` and `clearButtonContent`. Instead the new named slots should be used for customizing those buttons.